### PR TITLE
fix: correct Abraham Lincoln name in test

### DIFF
--- a/src/test/java/com/example/ZebraPRJ/ZebraPrjControllerTest.java
+++ b/src/test/java/com/example/ZebraPRJ/ZebraPrjControllerTest.java
@@ -134,13 +134,13 @@ class ZebraPrjControllerTest {
     @DisplayName("Check POST /users adds a new user")
     @Tag("Positive")
     void testPOSTNewUserSuccess() {
-        User newUser = new User(null, "Avraam Linkoln", "Avraam@mail.ru", LocalDate.of(1809, 2, 12));
+        User newUser = new User(null, "Abraham Lincoln", "Avraam@mail.ru", LocalDate.of(1809, 2, 12));
 
         // We can typically make a POST call here, but since the controller method
         // is designed to work with userRepository.save, this is a valid test of the underlying logic.
         User savedUser = userRepository.save(newUser);
         assertNotNull(savedUser.getId());
-        assertEquals("Avraam Linkoln", savedUser.getName());
+        assertEquals("Abraham Lincoln", savedUser.getName());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- fix Abraham Lincoln spelling in POST user test

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1d7bd46c833295c241a43262843e