### PR TITLE
refactor: rename package to lowercase

### DIFF
--- a/src/main/java/com/example/zebraprj/ZebraPrjApplication.java
+++ b/src/main/java/com/example/zebraprj/ZebraPrjApplication.java
@@ -1,4 +1,4 @@
-package com.example.ZebraPRJ;
+package com.example.zebraprj;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/example/zebraprj/ZebraPrjController.java
+++ b/src/main/java/com/example/zebraprj/ZebraPrjController.java
@@ -1,7 +1,7 @@
-package com.example.ZebraPRJ;
+package com.example.zebraprj;
 
-import com.example.ZebraPRJ.model.User;
-import com.example.ZebraPRJ.repository.UserRepository;
+import com.example.zebraprj.model.User;
+import com.example.zebraprj.repository.UserRepository;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/src/main/java/com/example/zebraprj/config/SwaggerConfig.java
+++ b/src/main/java/com/example/zebraprj/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.example.ZebraPRJ.config;
+package com.example.zebraprj.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;

--- a/src/main/java/com/example/zebraprj/grpc/UserGrpcServiceImpl.java
+++ b/src/main/java/com/example/zebraprj/grpc/UserGrpcServiceImpl.java
@@ -1,7 +1,7 @@
-package com.example.ZebraPRJ.grpc;
+package com.example.zebraprj.grpc;
 
-import com.example.ZebraPRJ.model.User;
-import com.example.ZebraPRJ.repository.UserRepository;
+import com.example.zebraprj.model.User;
+import com.example.zebraprj.repository.UserRepository;
 import io.grpc.stub.StreamObserver;
 import net.devh.boot.grpc.server.service.GrpcService;
 

--- a/src/main/java/com/example/zebraprj/model/User.java
+++ b/src/main/java/com/example/zebraprj/model/User.java
@@ -1,4 +1,4 @@
-package com.example.ZebraPRJ.model;
+package com.example.zebraprj.model;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;

--- a/src/main/java/com/example/zebraprj/repository/UserRepository.java
+++ b/src/main/java/com/example/zebraprj/repository/UserRepository.java
@@ -1,6 +1,6 @@
-package com.example.ZebraPRJ.repository;
+package com.example.zebraprj.repository;
 
-import com.example.ZebraPRJ.model.User;
+import com.example.zebraprj.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/proto/user.proto
+++ b/src/main/proto/user.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 option java_multiple_files = true; // Generate separate classes per message
-option java_package = "com.example.ZebraPRJ.grpc"; // Package for generated classes
+option java_package = "com.example.zebraprj.grpc"; // Package for generated classes
 option java_outer_classname = "UserProto"; // Outer class name wrapper
 
 // Message representing a user

--- a/src/test/java/com/example/zebraprj/AbstractPostgresTest.java
+++ b/src/test/java/com/example/zebraprj/AbstractPostgresTest.java
@@ -1,4 +1,4 @@
-package com.example.ZebraPRJ;
+package com.example.zebraprj;
 
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.testcontainers.containers.PostgreSQLContainer;

--- a/src/test/java/com/example/zebraprj/ZebraPrjControllerTest.java
+++ b/src/test/java/com/example/zebraprj/ZebraPrjControllerTest.java
@@ -1,7 +1,7 @@
-package com.example.ZebraPRJ;
+package com.example.zebraprj;
 
-import com.example.ZebraPRJ.model.User;
-import com.example.ZebraPRJ.repository.UserRepository;
+import com.example.zebraprj.model.User;
+import com.example.zebraprj.repository.UserRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeAll;

--- a/src/test/java/com/example/zebraprj/grpc/UserGrpcServiceImplTest.java
+++ b/src/test/java/com/example/zebraprj/grpc/UserGrpcServiceImplTest.java
@@ -1,8 +1,8 @@
-package com.example.ZebraPRJ.grpc;
+package com.example.zebraprj.grpc;
 
-import com.example.ZebraPRJ.model.User;
-import com.example.ZebraPRJ.AbstractPostgresTest;
-import com.example.ZebraPRJ.repository.UserRepository;
+import com.example.zebraprj.model.User;
+import com.example.zebraprj.AbstractPostgresTest;
+import com.example.zebraprj.repository.UserRepository;
 import io.grpc.StatusRuntimeException;
 import net.devh.boot.grpc.client.inject.GrpcClient;
 import org.junit.jupiter.api.*;


### PR DESCRIPTION
## Summary
- rename `com.example.ZebraPRJ` package to `com.example.zebraprj`
- update gRPC proto definition and tests for new package path

## Testing
- `mvn -q test` *(fails: Could not resolve parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0be005b6c8332ad398ed23c4c7bff